### PR TITLE
feat: portfolio visual updates round 3

### DIFF
--- a/.claude/skills/edit-copy/SKILL.md
+++ b/.claude/skills/edit-copy/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: edit-copy
+description: Edit and improve writing for clarity, tone, and correctness. Use for copywriting, proofreading, and editorial review of blog posts, project descriptions, or any site content.
+argument-hint: [file-path-or-topic]
+---
+
+Review and edit the content at `$ARGUMENTS` for quality, clarity, and consistency.
+
+## Editorial Process
+
+1. **Read the content** — understand the intent and audience.
+
+2. **Check for issues** in this order:
+   - **Spelling & grammar** — fix typos, subject-verb agreement, punctuation
+   - **Clarity** — simplify complex sentences, remove jargon, ensure ideas flow logically
+   - **Conciseness** — cut filler words, redundant phrases, and unnecessary qualifiers
+   - **Voice consistency** — match the site's tone: conversational, professional, first-person
+   - **Technical accuracy** — verify code references, tool names, and technical claims
+   - **Formatting** — proper Markdown headings, lists, code blocks, bold/italic usage
+
+3. **Site voice guidelines**:
+   - First person, conversational but professional
+   - Favor clarity over cleverness
+   - Short paragraphs (2-4 sentences)
+   - Use bold for key terms on first mention
+   - Avoid buzzwords and excessive jargon
+   - End sections with clear takeaways
+   - Lowercase headings match the site's aesthetic
+
+4. **Structural review**:
+   - Does the opening hook the reader?
+   - Do headings create a scannable outline?
+   - Is there a clear beginning, middle, and conclusion?
+   - Are code examples explained with context?
+   - Does the piece deliver on its title/description promise?
+
+5. **SEO check**:
+   - Does the `description` frontmatter field accurately summarize the content?
+   - Are `tags` relevant and consistent with existing tags on the site?
+   - Is the title clear and descriptive?
+
+6. **Present changes** — show a summary of edits made, grouped by category (grammar, clarity, structure, etc.). For substantial rewrites, explain the reasoning.
+
+## Quick Mode
+
+If the argument is a short phrase or sentence rather than a file path, treat it as inline copy to edit. Return the improved version with brief notes on what changed.

--- a/.claude/skills/new-blog-post/SKILL.md
+++ b/.claude/skills/new-blog-post/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: new-blog-post
+description: Create a new blog post with proper frontmatter, schema validation, and site integration. Use when adding writing or blog content to the site.
+argument-hint: [title]
+---
+
+Create a new blog post titled "$ARGUMENTS".
+
+## Steps
+
+1. **Generate the slug** from the title (lowercase, hyphens, no special characters).
+
+2. **Create the file** at `src/content/blog/<slug>.md` with this frontmatter:
+
+```yaml
+---
+title: "$ARGUMENTS"
+description: "<2-3 sentence summary>"
+pubDate: <today's date as YYYY-MM-DD>
+tags: [<relevant tags>]
+featured: false
+draft: false
+type: "writing"         # or "work" if it's a technical project writeup
+category: "<optional: content, data-analysis, web-development, automation>"
+view_source: "<optional: URL to source code>"
+---
+```
+
+3. **Frontmatter schema reference** (from `src/content/config.ts`):
+   - `title` (string, required)
+   - `description` (string, required)
+   - `pubDate` (Date, required)
+   - `updatedDate` (Date, optional)
+   - `tags` (string[], required)
+   - `featured` (boolean, default false)
+   - `draft` (boolean, default false)
+   - `author` (string, default "Andrew Getz")
+   - `type` (string, optional - "writing" or "work")
+   - `category` (string, optional)
+   - `view_source` (string/URL, optional)
+   - `image` (object with `src` and `alt`, optional)
+
+4. **Write the post body** in Markdown:
+   - Target 800-2000 words
+   - Use H2 (`##`) for main sections, H3 (`###`) for subsections
+   - Include code examples with proper syntax highlighting when relevant
+   - Voice: conversational but professional, avoid jargon
+   - End with a conclusion or takeaway
+
+5. **Check tag consistency** — read existing posts in `src/content/blog/` to reuse existing tags where appropriate rather than creating new ones.
+
+6. **Places that may need updating**:
+   - If `featured: true`, verify it appears on the homepage (`src/pages/index.astro`) in the featured section
+   - If adding a new `type` value, check that the filter buttons on `src/pages/work.astro` will pick it up (they auto-populate from content)
+   - If adding a new `category`, it will auto-appear in filters
+
+7. **Validate** by running `npm run build` to ensure no schema errors.
+
+## Writing Style Guide
+
+- Write in first person
+- Focus on practical insights over theory
+- Use short paragraphs and clear headings
+- Include "what I learned" or actionable takeaways
+- Bold key terms on first use
+- Keep sentences concise — favor clarity over cleverness

--- a/.claude/skills/new-project/SKILL.md
+++ b/.claude/skills/new-project/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: new-project
+description: Create a new project/work entry with proper frontmatter, schema validation, and site integration. Use when adding a project case study or work showcase.
+argument-hint: [project-title]
+---
+
+Create a new project entry titled "$ARGUMENTS".
+
+## Steps
+
+1. **Generate the slug** from the title (lowercase, hyphens, no special characters).
+
+2. **Create the file** at `src/content/projects/<slug>.md` with this frontmatter:
+
+```yaml
+---
+title: "$ARGUMENTS"
+description: "<brief 1-2 sentence description>"
+startDate: <YYYY-MM-DD>
+endDate: <YYYY-MM-DD or omit if ongoing>
+status: "completed"     # completed | in-progress | planned | archived
+featured: false
+category: "data-analysis"  # data-analysis | web-development | automation | content
+tags: [<general tags>]
+technologies: [<tech stack used>]
+type: "work"            # or "writing"
+view_source: "<optional: URL to source code>"
+github: "<optional: repo URL>"
+url: "<optional: live project URL>"
+client: "<optional: client name>"
+image:
+  src: "<optional: /images/hero.jpg>"
+  alt: "<optional: image description>"
+---
+```
+
+3. **Frontmatter schema reference** (from `src/content/config.ts`):
+   - `title` (string, required)
+   - `description` (string, required)
+   - `startDate` (Date, required)
+   - `endDate` (Date, optional)
+   - `status` (enum: completed/in-progress/planned/archived, required)
+   - `featured` (boolean, required)
+   - `category` (enum: web-development/data-analysis/automation/content, required)
+   - `tags` (string[], required)
+   - `technologies` (string[], required)
+   - `type` (string, optional)
+   - `view_source` (string/URL, optional)
+   - `github` (string/URL, optional)
+   - `url` (string/URL, optional)
+   - `client` (string, optional)
+   - `image` / `gallery` (optional)
+
+4. **Write the project body** as a case study in Markdown:
+   - **Project Overview** — what and why
+   - **Technical Implementation** — how it was built, key decisions
+   - **Results / Impact** — outcomes, metrics
+   - **Lessons Learned** — takeaways
+   - Include code snippets where relevant
+
+5. **Check tag/tech consistency** — read existing projects in `src/content/projects/` to reuse tags and technology names consistently.
+
+6. **Places that may need updating**:
+   - If `featured: true`, verify it shows on the homepage (`src/pages/index.astro`)
+   - The blog listing page (`src/pages/work.astro`) auto-discovers types, tags, and categories from content — no manual filter updates needed
+   - Project detail pages are auto-generated at `/work/<slug>/` via `src/pages/work/[...slug].astro`
+
+7. **Badge color conventions** used on the site:
+   - `badge-gray-subtle` — type (work/writing)
+   - `badge-teal-subtle` — category
+   - `badge-amber-subtle` — tags
+   - `badge-blue-subtle` — technologies (resume only)
+
+8. **Validate** by running `npm run build` to ensure no schema errors.

--- a/public/design-system.css
+++ b/public/design-system.css
@@ -339,18 +339,58 @@ button:focus {
   border: 1px solid rgba(20, 184, 166, 0.2);
 }
 
-/* Skill badge variants (reuse category colors) */
-.badge-development {
-  color: #0070f3;
-  background: rgba(0, 112, 243, 0.1);
-  border: 1px solid rgba(0, 112, 243, 0.2);
+/* Geist-style subtle badge variants */
+.badge-blue-subtle {
+  color: #3b82f6;
+  background: rgba(59, 130, 246, 0.1);
+  border: 1px solid rgba(59, 130, 246, 0.2);
 }
 
-.badge-tools {
-  color: #f97316;
-  background: rgba(249, 115, 22, 0.1);
-  border: 1px solid rgba(249, 115, 22, 0.2);
+.badge-amber-subtle {
+  color: #f59e0b;
+  background: rgba(245, 158, 11, 0.1);
+  border: 1px solid rgba(245, 158, 11, 0.2);
 }
+
+.badge-teal-subtle {
+  color: #14b8a6;
+  background: rgba(20, 184, 166, 0.1);
+  border: 1px solid rgba(20, 184, 166, 0.2);
+}
+
+.badge-gray-subtle {
+  color: #a1a1a1;
+  background: rgba(161, 161, 161, 0.1);
+  border: 1px solid rgba(161, 161, 161, 0.2);
+}
+
+.badge-purple-subtle {
+  color: #a855f7;
+  background: rgba(168, 85, 247, 0.1);
+  border: 1px solid rgba(168, 85, 247, 0.2);
+}
+
+.badge-green-subtle {
+  color: #22c55e;
+  background: rgba(34, 197, 94, 0.1);
+  border: 1px solid rgba(34, 197, 94, 0.2);
+}
+
+.badge-red-subtle {
+  color: #ef4444;
+  background: rgba(239, 68, 68, 0.1);
+  border: 1px solid rgba(239, 68, 68, 0.2);
+}
+
+.badge-pink-subtle {
+  color: #ec4899;
+  background: rgba(236, 72, 153, 0.1);
+  border: 1px solid rgba(236, 72, 153, 0.2);
+}
+
+/* Skill badge aliases */
+.badge-development { color: #3b82f6; background: rgba(59, 130, 246, 0.1); border: 1px solid rgba(59, 130, 246, 0.2); }
+.badge-tools { color: #f97316; background: rgba(249, 115, 22, 0.1); border: 1px solid rgba(249, 115, 22, 0.2); }
 
 /* Responsive Design */
 @media (max-width: 768px) {

--- a/src/components/SocialLinks.astro
+++ b/src/components/SocialLinks.astro
@@ -47,8 +47,7 @@ const socialLinks = [
     <a
       href={link.url}
       class="social-link"
-      target={link.url.startsWith('http') ? '_blank' : '_self'}
-      rel={link.url.startsWith('http') ? 'noopener noreferrer' : undefined}
+      {...(link.url.startsWith('http') ? { target: '_blank', rel: 'noopener noreferrer' } : {})}
       title={link.description}
       aria-label={link.description}
     >

--- a/src/content/blog/on-writing-and-development.md
+++ b/src/content/blog/on-writing-and-development.md
@@ -4,6 +4,8 @@ description: "Exploring the parallels between writing and programming, and how b
 pubDate: 2026-01-15
 tags: ["writing", "development", "process", "craft"]
 featured: false
+type: "writing"
+category: "content"
 ---
 
 I've been thinking lately about the similarities between writing and software development. Both are fundamentally about communication—whether you're communicating with future developers (including yourself) or with readers trying to understand an idea.

--- a/src/content/blog/welcome-to-my-new-site.md
+++ b/src/content/blog/welcome-to-my-new-site.md
@@ -4,6 +4,8 @@ description: "Introducing my redesigned portfolio built with Astro and following
 pubDate: 2026-02-11
 tags: ["announcement", "design", "astro"]
 featured: true
+type: "writing"
+category: "web-development"
 image:
   src: "/images/new-site-hero.jpg"
   alt: "Screenshot of the new portfolio design"

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -12,6 +12,9 @@ const blogCollection = defineCollection({
     featured: z.boolean().default(false),
     draft: z.boolean().default(false),
     author: z.string().default('Andrew Getz'),
+    type: z.enum(['writing', 'work']).default('writing'),
+    category: z.string().optional(),
+    view_source: z.string().url().optional(),
     image: z.object({
       src: z.string(),
       alt: z.string(),
@@ -32,6 +35,8 @@ const projectsCollection = defineCollection({
     tags: z.array(z.string()).default([]),
     technologies: z.array(z.string()).default([]),
     category: z.enum(['web-development', 'data-analysis', 'automation', 'content']),
+    type: z.enum(['writing', 'work']).default('work'),
+    view_source: z.string().url().optional(),
     client: z.string().optional(),
     url: z.string().url().optional(),
     github: z.string().url().optional(),

--- a/src/content/projects/data-analysis-dashboard.md
+++ b/src/content/projects/data-analysis-dashboard.md
@@ -8,6 +8,7 @@ featured: true
 category: "data-analysis"
 tags: ["python", "streamlit", "data-visualization", "pandas"]
 technologies: ["Python", "Streamlit", "Pandas", "Plotly", "PostgreSQL"]
+type: "work"
 client: "Local Business Client"
 image:
   src: "/images/dashboard-hero.jpg"

--- a/src/content/projects/portfolio-redesign.md
+++ b/src/content/projects/portfolio-redesign.md
@@ -8,7 +8,9 @@ featured: true
 category: "web-development"
 tags: ["astro", "design", "portfolio", "typescript"]
 technologies: ["Astro", "TypeScript", "CSS", "Geist Design System", "Vercel"]
-github: "https://github.com/andrewgetz/andrewgetzdata.github.io"
+type: "work"
+view_source: "https://github.com/andrewgetzdata/andrewgetzdata.github.io"
+github: "https://github.com/andrewgetzdata/andrewgetzdata.github.io"
 image:
   src: "/images/portfolio-redesign-hero.jpg"
   alt: "Screenshot of the new portfolio homepage"

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -129,7 +129,7 @@ const currentPath = Astro.url.pathname;
 
       <div class="nav-right">
         <a href="/" class={`nav-link ${currentPath === '/' ? 'active' : ''}`}>about</a>
-        <a href="/work" class={`nav-link ${currentPath.startsWith('/work') ? 'active' : ''}`}>work</a>
+        <a href="/work" class={`nav-link ${currentPath.startsWith('/work') || currentPath.startsWith('/blog') ? 'active' : ''}`}>blog</a>
         <a href="/resume" class={`nav-link ${currentPath.startsWith('/resume') ? 'active' : ''}`}>resume</a>
         <ThemeToggle />
       </div>

--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -21,13 +21,12 @@ type Props = {
 const post = Astro.props;
 const { Content } = await post.render();
 
-// Format date helper
+// Format date as YYYY-MM-DD
 function formatDate(date: Date): string {
-  return date.toLocaleDateString('en-US', {
-    year: 'numeric',
-    month: 'long',
-    day: 'numeric'
-  });
+  const y = date.getFullYear();
+  const m = String(date.getMonth() + 1).padStart(2, '0');
+  const d = String(date.getDate()).padStart(2, '0');
+  return `${y}-${m}-${d}`;
 }
 ---
 
@@ -41,167 +40,94 @@ function formatDate(date: Date): string {
   tags={post.data.tags}
 >
   <article class="blog-post">
-    <div class="container">
-      <div class="post-content">
-        <!-- Post Header -->
-        <header class="post-header">
-          <div class="breadcrumb">
-            <a href="/work">← Back to Work</a>
-          </div>
+    <div class="page-container">
+      <!-- Post Header -->
+      <header class="post-header">
+        <h1 class="post-title">{post.data.title}</h1>
 
-          <h1 class="post-title">{post.data.title}</h1>
-
-          <div class="post-meta">
-            <div class="meta-item">
-              <span class="meta-label">Published</span>
-              <time datetime={post.data.pubDate.toISOString()}>
-                {formatDate(post.data.pubDate)}
-              </time>
-            </div>
-
-            {post.data.updatedDate && (
-              <div class="meta-item">
-                <span class="meta-label">Updated</span>
-                <time datetime={post.data.updatedDate.toISOString()}>
-                  {formatDate(post.data.updatedDate)}
-                </time>
-              </div>
-            )}
-
-            <div class="meta-item">
-              <span class="meta-label">By</span>
-              <span class="author">{post.data.author}</span>
-            </div>
-
-            {post.data.featured && (
-              <div class="featured-badge">Featured Post</div>
-            )}
-          </div>
-
-          {post.data.tags.length > 0 && (
-            <div class="post-tags">
-              {post.data.tags.map((tag) => (
-                <span class="tag">{tag}</span>
-              ))}
-            </div>
+        <div class="post-meta">
+          <time datetime={post.data.pubDate.toISOString()}>
+            {formatDate(post.data.pubDate)}
+          </time>
+          <span class="meta-sep">|</span>
+          <span class="badge badge-gray-subtle">{post.data.type || 'writing'}</span>
+          {post.data.category && (
+            <>
+              <span class="meta-sep">|</span>
+              <span class="badge badge-teal-subtle">{post.data.category.replace('-', ' ')}</span>
+            </>
           )}
-        </header>
-
-        <!-- Post Body -->
-        <div class="post-body">
-          <Content />
+          {post.data.view_source && (
+            <>
+              <span class="meta-sep">|</span>
+              <a href={post.data.view_source} target="_blank" rel="noopener noreferrer" class="source-link">view source ↗</a>
+            </>
+          )}
         </div>
 
-        <!-- Post Footer -->
-        <footer class="post-footer">
-          <div class="post-actions">
-            <a href="/work" class="btn btn-secondary">← Back to Work</a>
+        {post.data.tags.length > 0 && (
+          <div class="post-tags">
+            {post.data.tags.map((tag: string) => (
+              <span class="badge badge-amber-subtle">{tag}</span>
+            ))}
           </div>
+        )}
+      </header>
 
-          <div class="post-share">
-            <h3>Share This Post</h3>
-            <div class="share-buttons">
-              <a
-                href={`https://twitter.com/intent/tweet?text=${encodeURIComponent(post.data.title)}&url=${encodeURIComponent(`https://andrewgetz.dev/blog/${post.slug}/`)}`}
-                target="_blank"
-                rel="noopener noreferrer"
-                class="share-button"
-              >
-                Twitter
-              </a>
-              <a
-                href={`https://www.linkedin.com/sharing/share-offsite/?url=${encodeURIComponent(`https://andrewgetz.dev/blog/${post.slug}/`)}`}
-                target="_blank"
-                rel="noopener noreferrer"
-                class="share-button"
-              >
-                LinkedIn
-              </a>
-            </div>
-          </div>
-        </footer>
+      <div class="divider" aria-hidden="true"></div>
+
+      <!-- Post Body -->
+      <div class="post-body">
+        <Content />
       </div>
     </div>
   </article>
 </BaseLayout>
 
 <style>
-  .blog-post {
-    padding: var(--space-12) 0;
-  }
-
-  .post-content {
-    max-width: 750px;
+  .page-container {
+    max-width: 48rem;
     margin: 0 auto;
-  }
-
-  .breadcrumb {
-    margin-bottom: var(--space-8);
-  }
-
-  .breadcrumb a {
-    color: var(--text-secondary);
-    text-decoration: none;
-    font-size: var(--text-sm);
-    transition: color var(--transition-fast);
-  }
-
-  .breadcrumb a:hover {
-    color: var(--text-primary);
-    text-decoration: none;
+    padding: 0 var(--space-6) var(--space-8);
   }
 
   .post-header {
-    margin-bottom: var(--space-12);
     text-align: center;
-    border-bottom: 1px solid var(--border-primary);
-    padding-bottom: var(--space-8);
+    padding: var(--space-8) 0 var(--space-6);
   }
 
   .post-title {
-    font-size: var(--text-4xl);
-    font-weight: 700;
-    color: var(--text-primary);
-    margin-bottom: var(--space-6);
-    line-height: var(--leading-tight);
+    margin-bottom: var(--space-3);
   }
 
   .post-meta {
     display: flex;
-    flex-wrap: wrap;
+    align-items: center;
     justify-content: center;
-    align-items: center;
-    gap: var(--space-6);
-    margin-bottom: var(--space-6);
-    color: var(--text-secondary);
-    font-size: var(--text-sm);
-  }
-
-  .meta-item {
-    display: flex;
-    align-items: center;
+    flex-wrap: wrap;
     gap: var(--space-2);
-  }
-
-  .meta-label {
+    font-family: var(--font-geist-mono);
+    font-size: var(--text-sm);
     color: var(--text-tertiary);
-    font-weight: 500;
+    margin-bottom: var(--space-5);
   }
 
-  .author {
+  .meta-sep {
+    color: var(--text-tertiary);
+    opacity: 0.5;
+  }
+
+  .source-link {
+    font-family: var(--font-geist-mono);
+    font-size: var(--text-sm);
+    color: var(--text-secondary);
+    text-decoration: none;
+    transition: color var(--transition-fast);
+  }
+
+  .source-link:hover {
     color: var(--text-primary);
-    font-weight: 500;
-  }
-
-  .featured-badge {
-    background-color: var(--accent-secondary);
-    color: var(--text-inverse);
-    padding: var(--space-1) var(--space-3);
-    border-radius: var(--radius);
-    font-size: var(--text-xs);
-    font-weight: 600;
-    text-transform: uppercase;
-    letter-spacing: 0.05em;
+    text-decoration: underline;
   }
 
   .post-tags {
@@ -211,17 +137,22 @@ function formatDate(date: Date): string {
     gap: var(--space-2);
   }
 
-  .tag {
-    background-color: var(--bg-tertiary);
-    color: var(--text-secondary);
+  .divider {
+    width: 100%;
+    overflow: hidden;
+    white-space: nowrap;
+    user-select: none;
+    margin-bottom: var(--space-8);
+  }
+
+  .divider::after {
+    content: "----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------";
+    font-family: var(--font-geist-mono);
     font-size: var(--text-xs);
-    padding: var(--space-1) var(--space-2);
-    border-radius: var(--radius-sm);
-    font-weight: 500;
+    color: var(--text-tertiary);
   }
 
   .post-body {
-    margin-bottom: var(--space-16);
     line-height: var(--leading-relaxed);
   }
 
@@ -317,112 +248,14 @@ function formatDate(date: Date): string {
     color: var(--text-primary);
   }
 
-  .post-footer {
-    border-top: 1px solid var(--border-primary);
-    padding-top: var(--space-8);
-    display: flex;
-    flex-direction: column;
-    gap: var(--space-8);
-  }
-
-  .post-actions {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    flex-wrap: wrap;
-    gap: var(--space-4);
-  }
-
-  .btn {
-    display: inline-flex;
-    align-items: center;
-    padding: var(--space-3) var(--space-6);
-    border-radius: var(--radius);
-    font-size: var(--text-sm);
-    font-weight: 500;
-    text-decoration: none;
-    transition: all var(--transition);
-    border: 1px solid;
-  }
-
-  .btn-primary {
-    background-color: var(--text-primary);
-    color: var(--bg-primary);
-    border-color: var(--text-primary);
-  }
-
-  .btn-primary:hover {
-    background-color: var(--text-secondary);
-    border-color: var(--text-secondary);
-    text-decoration: none;
-  }
-
-  .btn-secondary {
-    background-color: transparent;
-    color: var(--text-primary);
-    border-color: var(--border-primary);
-  }
-
-  .btn-secondary:hover {
-    background-color: var(--bg-hover);
-    border-color: var(--border-hover);
-    text-decoration: none;
-  }
-
-  .post-share h3 {
-    color: var(--text-primary);
-    font-size: var(--text-lg);
-    font-weight: 600;
-    margin-bottom: var(--space-4);
-  }
-
-  .share-buttons {
-    display: flex;
-    gap: var(--space-4);
-  }
-
-  .share-button {
-    display: inline-flex;
-    align-items: center;
-    padding: var(--space-2) var(--space-4);
-    background-color: var(--bg-tertiary);
-    color: var(--text-primary);
-    text-decoration: none;
-    border-radius: var(--radius);
-    font-size: var(--text-sm);
-    font-weight: 500;
-    transition: all var(--transition);
-    border: 1px solid var(--border-primary);
-  }
-
-  .share-button:hover {
-    background-color: var(--bg-hover);
-    border-color: var(--border-hover);
-    text-decoration: none;
-  }
-
   /* Responsive Design */
   @media (max-width: 768px) {
-    .blog-post {
-      padding: var(--space-8) 0;
+    .page-container {
+      padding: var(--space-6) var(--space-4);
     }
 
-    .post-title {
-      font-size: var(--text-3xl);
-    }
-
-    .post-meta {
-      flex-direction: column;
-      gap: var(--space-3);
-    }
-
-    .post-actions {
-      flex-direction: column;
-      align-items: stretch;
-    }
-
-    .share-buttons {
-      justify-content: center;
+    .post-header {
+      padding: var(--space-6) 0 var(--space-4);
     }
   }
 </style>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -75,16 +75,12 @@ function formatDate(date: Date): string {
                             <div class="item-top">
                                 <h3 class="item-title">{item.data.title}</h3>
                                 <div class="item-badges">
-                                    <span
-                                        class={`badge badge-${item.contentType}`}
-                                    >
+                                    <span class="badge badge-gray-subtle">
                                         {item.contentType}
                                     </span>
                                     {item.contentType === "work" &&
                                         "category" in item.data && (
-                                            <span
-                                                class={`badge badge-${item.data.category}`}
-                                            >
+                                            <span class="badge badge-teal-subtle">
                                                 {(
                                                     item.data.category as string
                                                 ).replace("-", " ")}
@@ -94,11 +90,11 @@ function formatDate(date: Date): string {
                             </div>
                             <p class="item-desc">{item.data.description}</p>
                             <div class="item-bottom">
-                                <span class="item-tags">
-                                    {item.data.tags
-                                        .slice(0, 3)
-                                        .join(" \u00B7 ")}
-                                </span>
+                                <div class="item-tags">
+                                    {item.data.tags.slice(0, 3).map((tag: string) => (
+                                        <span class="badge badge-amber-subtle">{tag}</span>
+                                    ))}
+                                </div>
                                 <span class="item-date">
                                     {formatDate(item.date)} &rarr;
                                 </span>
@@ -190,7 +186,7 @@ function formatDate(date: Date): string {
 
     .item-title {
         margin: 0;
-        font-family: var(--font-pixel-circle);
+        font-family: var(--font-pixel-square);
         font-size: var(--text-base);
         font-weight: 500;
         color: var(--text-primary);
@@ -223,8 +219,9 @@ function formatDate(date: Date): string {
     }
 
     .item-tags {
-        font-size: var(--text-xs);
-        color: var(--text-tertiary);
+        display: flex;
+        flex-wrap: wrap;
+        gap: var(--space-1);
     }
 
     .item-date {

--- a/src/pages/resume.astro
+++ b/src/pages/resume.astro
@@ -1,304 +1,755 @@
 ---
 // Resume Page - Andrew Getz Portfolio
-import BaseLayout from '../layouts/BaseLayout.astro';
-import SocialLinks from '../components/SocialLinks.astro';
+import BaseLayout from "../layouts/BaseLayout.astro";
+import SocialLinks from "../components/SocialLinks.astro";
 ---
 
 <BaseLayout
-  title="Resume - Andrew Getz"
-  description="Professional resume of Andrew Getz - AI & data engineer with expertise in analytics and machine learning."
+    title="Resume - Andrew Getz"
+    description="Professional resume of Andrew Getz - Analytics Engineer with expertise in data engineering, visualization, and machine learning."
 >
-  <div class="page-container">
-    <!-- Header -->
-    <section class="section resume-header">
-      <h1>AI & Data Engineer</h1>
-      <p class="resume-credentials">MS Data Science · Analytics · Machine Learning</p>
-    </section>
+    <div class="page-container">
+        <!-- Header -->
+        <section class="section resume-header">
+            <h1>Builder</h1>
+            <p class="resume-credentials">
+                Analytics · Data · Artificial Intelligence
+            </p>
+        </section>
 
-    <hr />
+        <!-- Experience -->
+        <section class="section resume-section">
+            <div class="section-box">
+                <h2>Experience</h2>
+            </div>
+            <div class="collapse-group">
+                <details class="collapse-item">
+                    <summary class="collapse-summary">
+                        <div class="collapse-title-row">
+                            <h3>
+                                Lead Analytics Engineer <span class="title-sep"
+                                    >|</span
+                                > Fountain
+                            </h3>
+                            <span class="experience-period"
+                                >Dec 2024 - Present</span
+                            >
+                        </div>
+                        <svg
+                            class="collapse-chevron"
+                            width="16"
+                            height="16"
+                            viewBox="0 0 16 16"
+                            fill="none"
+                            ><path
+                                d="M4 6L8 10L12 6"
+                                stroke="currentColor"
+                                stroke-width="1.5"
+                                stroke-linecap="round"
+                                stroke-linejoin="round"></path></svg
+                        >
+                    </summary>
+                    <div class="collapse-content">
+                        <ul class="experience-details">
+                            <li>
+                                Developed an embedded network of AI agents that
+                                delivered real-time insights and hiring
+                                optimization recommendations, enabling users to
+                                enhance their product implementation through
+                                conversational AI interactions
+                            </li>
+                            <li>
+                                Led a complete warehouse and data transformation
+                                migration project for internal stakeholders and
+                                embedded customers from BigQuery to ClickHouse
+                                using a data lake architecture in S3, saving
+                                $400,000 in renewal contract costs
+                            </li>
+                            <li>
+                                Developed new product capabilities in the
+                                migration to address customer needs including
+                                NRT data availability, 75% faster refreshes, 50%
+                                faster embedded queries, and laid the foundation
+                                for the next stage of Fountain’s product growth
+                            </li>
+                            <li>
+                                Internal self-serve data models have experienced
+                                67% increase in adoption rate; moving from
+                                reporting tools to strategic decision support to
+                                inform the product roadmap, develop new GTM
+                                strategies, and enable revenue growth
+                            </li>
+                        </ul>
+                    </div>
+                </details>
 
-    <!-- Professional Summary -->
-    <section class="section resume-section">
-      <h2>Professional Summary</h2>
-      <p>
-        Developer and data analyst with a passion for creating meaningful digital experiences
-        and extracting actionable insights from complex datasets. Combines technical expertise
-        with strong communication skills to bridge the gap between data and decision-making.
-        Committed to clean code, thoughtful design, and solving real-world problems.
-      </p>
-    </section>
+                <details class="collapse-item">
+                    <summary class="collapse-summary">
+                        <div class="collapse-title-row">
+                            <h3>
+                                Senior Analytics Engineer <span
+                                    class="title-sep">|</span
+                                > Fountain
+                            </h3>
+                            <span class="experience-period"
+                                >Mar 2024 - Dec 2024</span
+                            >
+                        </div>
+                        <svg
+                            class="collapse-chevron"
+                            width="16"
+                            height="16"
+                            viewBox="0 0 16 16"
+                            fill="none"
+                            ><path
+                                d="M4 6L8 10L12 6"
+                                stroke="currentColor"
+                                stroke-width="1.5"
+                                stroke-linecap="round"
+                                stroke-linejoin="round"></path></svg
+                        >
+                    </summary>
+                    <div class="collapse-content">
+                        <ul class="experience-details">
+                            <li>
+                                Led the constant growth and iteration of a
+                                large, complex, multi-project data model built
+                                in dbt core with ~50K daily materializations
+                                that supports all Fountain customers across 8
+                                products, custom reporting, and internal data
+                                stakeholder resources including enterprise
+                                reporting, revenue operations, marketing,
+                                finance, and customer support
+                            </li>
+                            <li>
+                                Implemented query and model efficiency
+                                enhancements to decrease annual BigQuery compute
+                                cost by ~$250,000
+                            </li>
+                            <li>
+                                Serve as a technical lead and thought leader,
+                                providing technical guidance, reinforcing best
+                                practices, reviewing work, and raising the bar
+                                of quality engineering and analysis across the
+                                data team and guiding cross-functional
+                                stakeholders
+                            </li>
+                        </ul>
+                    </div>
+                </details>
 
-    <hr />
+                <details class="collapse-item">
+                    <summary class="collapse-summary">
+                        <div class="collapse-title-row">
+                            <h3>
+                                Founding Analytics Engineer <span
+                                    class="title-sep">|</span
+                                > Fountain
+                            </h3>
+                            <span class="experience-period"
+                                >Jul 2023 - Mar 2024</span
+                            >
+                        </div>
+                        <svg
+                            class="collapse-chevron"
+                            width="16"
+                            height="16"
+                            viewBox="0 0 16 16"
+                            fill="none"
+                            ><path
+                                d="M4 6L8 10L12 6"
+                                stroke="currentColor"
+                                stroke-width="1.5"
+                                stroke-linecap="round"
+                                stroke-linejoin="round"></path></svg
+                        >
+                    </summary>
+                    <div class="collapse-content">
+                        <ul class="experience-details">
+                            <li>
+                                Founding member of the Analytics Engineering
+                                function and owner of the Analytics Engineering
+                                roadmap and results
+                            </li>
+                            <li>
+                                Implemented dbt in one quarter from end-to-end,
+                                including orchestration, transformation, and
+                                end-user-facing semantic layer of our data
+                                pipelines in LookML, visualized in Looker and
+                                embedded in the Fountain Hire product
+                            </li>
+                            <li>
+                                Led the strategic initiative to redesign our
+                                data model and Looker semantic layer using data
+                                and engineering best practices, leading to an
+                                86% decrease in Looker load times and 99%
+                                decrease in compute time for the same reports
+                            </li>
+                            <li>
+                                Successfully advocated for and owned the
+                                implementation of a modern data stack (dbt /
+                                Dagster), significantly enhancing the
+                                competitive advantage of our analytics product
+                                (~ 14K users) and our capacity for data-driven
+                                decisions
+                            </li>
+                            <li>
+                                Responsible for approving PRs for changes to the
+                                transformation layer in dbt and our semantic
+                                layers built in LookML
+                            </li>
+                        </ul>
+                    </div>
+                </details>
 
-    <!-- Experience -->
-    <section class="section resume-section">
-      <h2>Experience</h2>
-      <div class="experience-list">
-        <div class="experience-item">
-          <div class="experience-header">
-            <h3>Data Analyst & Developer</h3>
-            <span class="experience-period">2020 - Present</span>
-          </div>
-          <p class="experience-company">Freelance & Contract Work</p>
-          <ul class="experience-details">
-            <li>Develop web applications and data analysis solutions for diverse clients</li>
-            <li>Create interactive dashboards and reporting tools using modern web technologies</li>
-            <li>Design and implement data processing pipelines and analytical workflows</li>
-            <li>Collaborate with stakeholders to translate business requirements into technical solutions</li>
-          </ul>
-        </div>
+                <details class="collapse-item">
+                    <summary class="collapse-summary">
+                        <div class="collapse-title-row">
+                            <h3>
+                                Data Analyst <span class="title-sep">|</span> Fountain
+                            </h3>
+                            <span class="experience-period"
+                                >May 2022 - Jul 2023</span
+                            >
+                        </div>
+                        <svg
+                            class="collapse-chevron"
+                            width="16"
+                            height="16"
+                            viewBox="0 0 16 16"
+                            fill="none"
+                            ><path
+                                d="M4 6L8 10L12 6"
+                                stroke="currentColor"
+                                stroke-width="1.5"
+                                stroke-linecap="round"
+                                stroke-linejoin="round"></path></svg
+                        >
+                    </summary>
+                    <div class="collapse-content">
+                        <ul class="experience-details">
+                            <li>
+                                Own standard and custom reporting and analytics
+                                requests for Fountain’s portfolio of strategic
+                                enterprise customers
+                            </li>
+                            <li>
+                                Deployment manager and owner of the internal and
+                                customer-facing transformation layers of our
+                                data in Looker
+                            </li>
+                            <li>
+                                Built custom reports and analysis to support
+                                sales and increase revenue, including a $50,000
+                                reporting package
+                            </li>
+                            <li>
+                                Developed an ‘Anatomy Detection’ bot that sends
+                                alerts for large KPI changes, attributed with
+                                $100,000 in savings
+                            </li>
+                            <li>
+                                Partnered across teams to build and implement an
+                                automated, secure, customer facing, custom
+                                report-sharing
+                            </li>
+                        </ul>
+                    </div>
+                </details>
 
-        <div class="experience-item">
-          <div class="experience-header">
-            <h3>Previous Professional Experience</h3>
-            <span class="experience-period">2015 - 2020</span>
-          </div>
-          <p class="experience-company">Various Organizations</p>
-          <ul class="experience-details">
-            <li>Developed analytical frameworks and reporting systems</li>
-            <li>Improved data quality and process efficiency through automation</li>
-            <li>Presented findings and recommendations to leadership teams</li>
-          </ul>
-        </div>
-      </div>
-    </section>
+                <details class="collapse-item">
+                    <summary class="collapse-summary">
+                        <div class="collapse-title-row">
+                            <h3>
+                                Customer Experience Data Analyst <span
+                                    class="title-sep">|</span
+                                > Root Inc.
+                            </h3>
+                            <span class="experience-period"
+                                >Nov 2021 - May 2022</span
+                            >
+                        </div>
+                        <svg
+                            class="collapse-chevron"
+                            width="16"
+                            height="16"
+                            viewBox="0 0 16 16"
+                            fill="none"
+                            ><path
+                                d="M4 6L8 10L12 6"
+                                stroke="currentColor"
+                                stroke-width="1.5"
+                                stroke-linecap="round"
+                                stroke-linejoin="round"></path></svg
+                        >
+                    </summary>
+                    <div class="collapse-content">
+                        <ul class="experience-details">
+                            <li>
+                                Analytics and reporting owner for the Customer
+                                Service, Internal Sales Agency, Claims Support &
+                                Carvana Ops Teams
+                            </li>
+                            <li>
+                                Built robust and stable data and reporting
+                                infrastructure from the ground up using SQL
+                                pipelines, visualized in Tableau
+                            </li>
+                            <li>
+                                Designed and developed an internal QA system to
+                                replace a software vendor, eliminating a $60,000
+                                annual expense
+                            </li>
+                            <li>
+                                Provided recommendations to leadership regarding
+                                team operations, resulting in a 25% increase in
+                                service level
+                            </li>
+                            <li>
+                                Onboarded, coached, and managed the daily work
+                                of the Operations Data Analyst to become an
+                                effective contributor
+                            </li>
+                        </ul>
+                    </div>
+                </details>
 
-    <hr />
+                <details class="collapse-item">
+                    <summary class="collapse-summary">
+                        <div class="collapse-title-row">
+                            <h3>
+                                Customer Service Operations Data Analyst <span
+                                    class="title-sep">|</span
+                                > Root Inc.
+                            </h3>
+                            <span class="experience-period"
+                                >Feb 2021 - Nov 2021</span
+                            >
+                        </div>
+                        <svg
+                            class="collapse-chevron"
+                            width="16"
+                            height="16"
+                            viewBox="0 0 16 16"
+                            fill="none"
+                            ><path
+                                d="M4 6L8 10L12 6"
+                                stroke="currentColor"
+                                stroke-width="1.5"
+                                stroke-linecap="round"
+                                stroke-linejoin="round"></path></svg
+                        >
+                    </summary>
+                    <div class="collapse-content">
+                        <ul class="experience-details">
+                            <li>
+                                Analytics and reporting owner for a rapidly
+                                scaling Internal Sales Agency, accounting for
+                                >20% of Root’s 2021 policies
+                            </li>
+                            <li>
+                                Built automated analytic tools to empower
+                                stakeholders that save 20+ hours a week in
+                                repetitive analysis tasks
+                            </li>
+                        </ul>
+                    </div>
+                </details>
+            </div>
+        </section>
 
-    <!-- Education & Learning -->
-    <section class="section resume-section">
-      <h2>Education & Learning</h2>
-      <div class="education-item">
-        <h3>Continuous Learning</h3>
-        <p>
-          Self-directed study in modern web development, data science, and statistical analysis.
-          Active participant in developer communities and ongoing professional development.
-        </p>
-      </div>
-    </section>
+        <!-- Education -->
+        <section class="section resume-section">
+            <div class="section-box">
+                <h2>Education</h2>
+            </div>
+            <div class="education-grid">
+                <div class="education-col">
+                    <h3 class="education-school">Georgia Institute of Technology</h3>
+                    <p class="education-degree">Masters of Science in Analytics</p>
+                </div>
+                <div class="education-col">
+                    <h3 class="education-school">The Ohio State University, Fisher College of Business</h3>
+                    <p class="education-degree">Bachelor of Science in Business Administration</p>
+                </div>
+            </div>
+        </section>
 
-    <hr />
+        <!-- Technical Skills -->
+        <section class="section resume-section">
+            <div class="section-box">
+                <h2>Technical Skills</h2>
+            </div>
 
-    <!-- Technical Skills -->
-    <section class="section resume-section">
-      <h2>Technical Skills</h2>
+            <div class="skill-group">
+                <h3>Data Visualization</h3>
+                <div class="skill-badges">
+                    <span class="badge badge-blue-subtle">Looker</span>
+                    <span class="badge badge-blue-subtle">Omni</span>
+                    <span class="badge badge-blue-subtle">Mode</span>
+                    <span class="badge badge-blue-subtle">Tableau</span>
+                </div>
+            </div>
 
-      <div class="skill-group">
-        <h3>Development</h3>
-        <div class="skill-badges">
-          <span class="badge badge-development">JavaScript/TypeScript</span>
-          <span class="badge badge-development">Python</span>
-          <span class="badge badge-development">HTML/CSS</span>
-          <span class="badge badge-development">React/Astro</span>
-          <span class="badge badge-development">Node.js</span>
-        </div>
-      </div>
+            <div class="skill-group">
+                <h3>Analytics Engineering</h3>
+                <div class="skill-badges">
+                    <span class="badge badge-purple-subtle">Data Modeling</span>
+                    <span class="badge badge-purple-subtle">Transformation</span
+                    >
+                    <span class="badge badge-purple-subtle"
+                        >Self-Serve Analytics</span
+                    >
+                    <span class="badge badge-purple-subtle">Metric Trees</span>
+                </div>
+            </div>
 
-      <div class="skill-group">
-        <h3>Data Analysis</h3>
-        <div class="skill-badges">
-          <span class="badge badge-data-analysis">Statistical Analysis</span>
-          <span class="badge badge-data-analysis">Data Visualization</span>
-          <span class="badge badge-data-analysis">SQL</span>
-          <span class="badge badge-data-analysis">Pandas/NumPy</span>
-          <span class="badge badge-data-analysis">Streamlit</span>
-        </div>
-      </div>
+            <div class="skill-group">
+                <h3>Data Engineering</h3>
+                <div class="skill-badges">
+                    <span class="badge badge-teal-subtle"
+                        >ETL Pipeline Development</span
+                    >
+                    <span class="badge badge-teal-subtle"
+                        >Query Optimization</span
+                    >
+                    <span class="badge badge-teal-subtle">Orchestration</span>
+                    <span class="badge badge-teal-subtle">CI/CD</span>
+                </div>
+            </div>
 
-      <div class="skill-group">
-        <h3>Tools</h3>
-        <div class="skill-badges">
-          <span class="badge badge-tools">Git/GitHub</span>
-          <span class="badge badge-tools">VS Code</span>
-          <span class="badge badge-tools">Docker</span>
-          <span class="badge badge-tools">Linux/MacOS</span>
-          <span class="badge badge-tools">Jupyter</span>
-        </div>
-      </div>
-    </section>
+            <div class="skill-group">
+                <h3>Analysis Techniques</h3>
+                <div class="skill-badges">
+                    <span class="badge badge-amber-subtle"
+                        >Hypothesis Testing</span
+                    >
+                    <span class="badge badge-amber-subtle">A/B Testing</span>
+                    <span class="badge badge-amber-subtle"
+                        >Regression Analysis</span
+                    >
+                    <span class="badge badge-amber-subtle">SVMs</span>
+                    <span class="badge badge-amber-subtle">Decision Trees</span>
+                    <span class="badge badge-amber-subtle"
+                        >Time Series Analysis</span
+                    >
+                    <span class="badge badge-amber-subtle"
+                        >k-means Clustering</span
+                    >
+                    <span class="badge badge-amber-subtle"
+                        >Anomaly Detection</span
+                    >
+                    <span class="badge badge-amber-subtle">Random Forests</span>
+                    <span class="badge badge-amber-subtle">NLP</span>
+                </div>
+            </div>
 
-    <hr />
+            <div class="skill-group">
+                <h3>Tools & Frameworks</h3>
+                <div class="skill-badges">
+                    <span class="badge badge-green-subtle">Advanced SQL</span>
+                    <span class="badge badge-green-subtle">ClickHouse</span>
+                    <span class="badge badge-green-subtle">BigQuery</span>
+                    <span class="badge badge-green-subtle">Redshift</span>
+                    <span class="badge badge-green-subtle">Snowflake</span>
+                    <span class="badge badge-green-subtle">dbt</span>
+                    <span class="badge badge-green-subtle">Dagster</span>
+                    <span class="badge badge-green-subtle">Python</span>
+                    <span class="badge badge-green-subtle">R</span>
+                    <span class="badge badge-green-subtle">Jupyter</span>
+                    <span class="badge badge-green-subtle">Hex</span>
+                    <span class="badge badge-green-subtle">Google Colab</span>
+                    <span class="badge badge-green-subtle">Fivetran</span>
+                    <span class="badge badge-green-subtle">Git & GitHub</span>
+                </div>
+            </div>
+        </section>
 
-    <!-- Get In Touch -->
-    <section class="section" id="contact">
-      <h2>Get In Touch</h2>
-      <p>
-        Want to work together or just say hi?
-        The fastest way to reach me is a DM.
-      </p>
-      <SocialLinks layout="horizontal" showLabels={true} size="md" />
-    </section>
-  </div>
+        <div class="divider" aria-hidden="true"></div>
+
+        <!-- Get In Touch -->
+        <section class="section" id="contact">
+            <h2>Get In Touch</h2>
+            <p>
+                Want to work together or just say hi? The fastest way to reach
+                me is a DM.
+            </p>
+            <SocialLinks layout="horizontal" showLabels={true} size="md" />
+        </section>
+    </div>
 </BaseLayout>
 
 <style>
-  .page-container {
-    max-width: 48rem;
-    margin: 0 auto;
-    padding: 0 var(--space-6) var(--space-8);
-  }
-
-  .section {
-    padding: var(--space-6) 0;
-  }
-
-  hr {
-    border: none;
-    border-top: 1px solid var(--border-primary);
-    margin: 0;
-  }
-
-  .resume-header h1 {
-    margin-bottom: var(--space-2);
-  }
-
-  .resume-credentials {
-    font-size: var(--text-lg);
-    color: var(--text-secondary);
-    font-weight: 500;
-    margin: 0;
-  }
-
-  .resume-section h2 {
-    font-family: var(--font-geist-sans);
-    font-size: var(--text-xl);
-    font-weight: 600;
-    color: var(--text-primary);
-    text-transform: none;
-    letter-spacing: -0.02em;
-    -webkit-font-smoothing: antialiased;
-    -moz-osx-font-smoothing: grayscale;
-    margin-bottom: var(--space-6);
-    padding-bottom: var(--space-2);
-    border-bottom: 1px solid var(--border-secondary);
-  }
-
-  .resume-section p {
-    color: var(--text-secondary);
-    line-height: var(--leading-relaxed);
-    margin-bottom: var(--space-4);
-  }
-
-  .experience-item {
-    margin-bottom: var(--space-8);
-  }
-
-  .experience-item:last-child {
-    margin-bottom: 0;
-  }
-
-  .experience-header {
-    display: flex;
-    justify-content: space-between;
-    align-items: baseline;
-    margin-bottom: var(--space-2);
-  }
-
-  .experience-header h3 {
-    font-size: var(--text-lg);
-    font-weight: 600;
-    color: var(--text-primary);
-    margin: 0;
-  }
-
-  .experience-period {
-    font-size: var(--text-sm);
-    color: var(--text-tertiary);
-    font-weight: 500;
-  }
-
-  .experience-company {
-    font-size: var(--text-base);
-    color: var(--text-secondary);
-    font-weight: 500;
-    margin-bottom: var(--space-3);
-  }
-
-  .experience-details {
-    margin: 0;
-    padding-left: var(--space-5);
-  }
-
-  .experience-details li {
-    color: var(--text-secondary);
-    margin-bottom: var(--space-2);
-    font-size: var(--text-sm);
-    line-height: var(--leading-normal);
-  }
-
-  .education-item h3 {
-    font-size: var(--text-lg);
-    font-weight: 600;
-    color: var(--text-primary);
-    margin-bottom: var(--space-3);
-  }
-
-  .education-item p {
-    color: var(--text-secondary);
-    line-height: var(--leading-relaxed);
-    margin: 0;
-  }
-
-  .skill-group {
-    margin-bottom: var(--space-6);
-  }
-
-  .skill-group:last-child {
-    margin-bottom: 0;
-  }
-
-  .skill-group h3 {
-    font-size: var(--text-sm);
-    font-weight: 600;
-    color: var(--text-tertiary);
-    text-transform: uppercase;
-    letter-spacing: 0.05em;
-    margin-bottom: var(--space-3);
-  }
-
-  .skill-badges {
-    display: flex;
-    flex-wrap: wrap;
-    gap: var(--space-2);
-  }
-
-  /* Print Styles */
-  @media print {
     .page-container {
-      padding: 0;
-      max-width: none;
+        max-width: 48rem;
+        margin: 0 auto;
+        padding: 0 var(--space-6) var(--space-8);
     }
 
     .section {
-      page-break-inside: avoid;
+        padding: var(--space-6) 0;
     }
 
-    .experience-item {
-      page-break-inside: avoid;
+    .divider {
+        width: 100%;
+        overflow: hidden;
+        white-space: nowrap;
+        user-select: none;
+        line-height: 1;
     }
 
-    body {
-      font-size: 12px;
-      line-height: 1.4;
-      color: #000;
-      background: white;
-    }
-  }
-
-  /* Responsive Design */
-  @media (max-width: 768px) {
-    .page-container {
-      padding: var(--space-8) var(--space-4);
+    .divider::after {
+        content: "----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------";
+        font-family: var(--font-geist-mono);
+        font-size: var(--text-xs);
+        color: var(--text-tertiary);
     }
 
-    .section {
-      padding: var(--space-8) 0;
+    .resume-header.section {
+        padding-top: 0;
     }
 
-    .experience-header {
-      flex-direction: column;
-      align-items: flex-start;
-      gap: var(--space-1);
+    .resume-header h1 {
+        margin-bottom: var(--space-2);
     }
-  }
+
+    .resume-credentials {
+        font-size: var(--text-lg);
+        color: var(--text-secondary);
+        font-weight: 500;
+        margin: 0;
+    }
+
+    .resume-section.section {
+        padding-top: 0;
+        padding-bottom: 0;
+    }
+
+    .resume-section h2 {
+        font-family: var(--font-geist-sans);
+        font-size: var(--text-xl);
+        font-weight: 600;
+        color: var(--text-primary);
+        text-transform: none;
+        letter-spacing: -0.02em;
+        -webkit-font-smoothing: antialiased;
+        -moz-osx-font-smoothing: grayscale;
+        margin-bottom: var(--space-6);
+    }
+
+    .resume-section p {
+        color: var(--text-secondary);
+        line-height: var(--leading-relaxed);
+        margin-bottom: var(--space-4);
+    }
+
+    /* Collapse Group */
+    .collapse-group {
+        display: flex;
+        flex-direction: column;
+    }
+
+    .collapse-item {
+        border-bottom: 1px solid var(--border-primary);
+    }
+
+    .collapse-item:first-child {
+        border-top: 1px solid var(--border-primary);
+    }
+
+    .collapse-summary {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        padding: var(--space-4) 0;
+        cursor: pointer;
+        list-style: none;
+        gap: var(--space-3);
+    }
+
+    .collapse-summary::-webkit-details-marker {
+        display: none;
+    }
+
+    .collapse-summary::marker {
+        display: none;
+        content: "";
+    }
+
+    .collapse-title-row {
+        display: flex;
+        justify-content: space-between;
+        align-items: baseline;
+        flex: 1;
+        min-width: 0;
+    }
+
+    .collapse-title-row h3 {
+        font-size: var(--text-base);
+        font-weight: 500;
+        color: var(--text-primary);
+        margin: 0;
+    }
+
+    .title-sep {
+        color: var(--text-tertiary);
+        margin: 0 var(--space-1);
+        font-weight: 400;
+    }
+
+    .experience-period {
+        font-family: var(--font-geist-mono);
+        font-size: var(--text-xs);
+        color: var(--text-tertiary);
+        font-weight: 400;
+        white-space: nowrap;
+        margin-left: var(--space-3);
+    }
+
+    .collapse-chevron {
+        color: var(--text-tertiary);
+        transition: transform 0.2s ease;
+        flex-shrink: 0;
+    }
+
+    .collapse-item[open] .collapse-chevron {
+        transform: rotate(180deg);
+    }
+
+    .collapse-content {
+        padding: 0 0 var(--space-4) 0;
+    }
+
+    .experience-details {
+        margin: 0;
+        padding-left: var(--space-5);
+    }
+
+    .experience-details li {
+        color: var(--text-secondary);
+        margin-bottom: var(--space-2);
+        font-size: var(--text-sm);
+        line-height: var(--leading-normal);
+    }
+
+    .experience-details li:last-child {
+        margin-bottom: 0;
+    }
+
+    /* Education Grid */
+    .education-grid {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: var(--space-6);
+        padding: var(--space-2) 0;
+    }
+
+    .education-school {
+        font-size: var(--text-base);
+        font-weight: 600;
+        color: var(--text-primary);
+        margin: 0 0 var(--space-1) 0;
+    }
+
+    .education-degree {
+        font-size: var(--text-sm);
+        color: var(--text-secondary);
+        margin: 0;
+    }
+
+    /* Section Box Header */
+    .section-box {
+        border: 1px dashed var(--text-tertiary);
+        padding: var(--space-3) var(--space-4);
+        margin-bottom: var(--space-4);
+        margin-top: 0;
+    }
+
+    .section-box h2 {
+        margin-bottom: 0;
+        font-family: var(--font-pixel-square);
+        text-transform: lowercase;
+        text-align: center;
+        font-weight: 700;
+        letter-spacing: 0.02em;
+    }
+
+    .skill-group {
+        margin-bottom: var(--space-6);
+    }
+
+    .skill-group:last-child {
+        margin-bottom: 0;
+    }
+
+    .skill-group h3 {
+        font-size: var(--text-sm);
+        font-weight: 600;
+        color: var(--text-tertiary);
+        text-transform: uppercase;
+        letter-spacing: 0.05em;
+        margin-bottom: var(--space-3);
+    }
+
+    .skill-badges {
+        display: flex;
+        flex-wrap: wrap;
+        gap: var(--space-2);
+    }
+
+    /* Print Styles */
+    @media print {
+        .page-container {
+            padding: 0;
+            max-width: none;
+        }
+
+        .section {
+            page-break-inside: avoid;
+        }
+
+        .collapse-item {
+            page-break-inside: avoid;
+        }
+
+        .collapse-content {
+            display: block !important;
+        }
+
+        .collapse-chevron {
+            display: none;
+        }
+
+        body {
+            font-size: 12px;
+            line-height: 1.4;
+            color: #000;
+            background: white;
+        }
+    }
+
+    /* Responsive Design */
+    @media (max-width: 768px) {
+        .page-container {
+            padding: var(--space-8) var(--space-4);
+        }
+
+        .section {
+            padding: var(--space-8) 0;
+        }
+
+        .collapse-title-row {
+            flex-direction: column;
+            align-items: flex-start;
+            gap: var(--space-1);
+        }
+
+        .experience-period {
+            margin-left: 0;
+        }
+
+        .education-grid {
+            grid-template-columns: 1fr;
+        }
+    }
 </style>

--- a/src/pages/work.astro
+++ b/src/pages/work.astro
@@ -25,8 +25,11 @@ const projects = (await getCollection('projects'))
 const allContent = [...blogPosts, ...projects]
   .sort((a, b) => b.date.getTime() - a.date.getTime());
 
-// Collect unique content types for filter buttons
-const types = ['all', ...new Set(allContent.map(c => c.contentType))];
+// Collect unique types from frontmatter
+const types = ['all', ...new Set(allContent.map(c => c.data.type || c.contentType))];
+
+// Collect unique tags from all content
+const allTags = [...new Set(allContent.flatMap(c => c.data.tags))].sort();
 
 function formatDate(date: Date): string {
   return date.toLocaleDateString('en-US', { year: 'numeric', month: 'short' });
@@ -39,36 +42,43 @@ function formatDate(date: Date): string {
 >
   <div class="page-container">
     <section class="section">
-      <h1>Work & Writing</h1>
-
       <div class="filters" role="group" aria-label="Filter content">
         {types.map(type => (
           <button
             class={`filter-btn ${type === 'all' ? 'active' : ''}`}
             data-filter={type}
           >
-            {type}
+            {type === 'all' ? 'all types' : type}
           </button>
+        ))}
+      </div>
+
+      <div class="filters" role="group" aria-label="Filter by tag">
+        <button class="filter-btn tag-btn active" data-tag="all">all tags</button>
+        {allTags.map(tag => (
+          <button class="filter-btn tag-btn" data-tag={tag}>{tag}</button>
         ))}
       </div>
 
       <div class="items">
         {allContent.map(item => (
-          <a href={item.href} class="item" data-type={item.contentType}>
+          <a href={item.href} class="item" data-type={item.data.type || item.contentType} data-tags={item.data.tags.join(',')}>
             <div class="item-top">
               <h3 class="item-title">{item.data.title}</h3>
               <div class="item-badges">
-                <span class={`badge badge-${item.contentType}`}>{item.contentType}</span>
+                <span class="badge badge-gray-subtle">{item.data.type || item.contentType}</span>
                 {item.contentType === 'work' && 'category' in item.data && (
-                  <span class={`badge badge-${item.data.category}`}>{(item.data.category as string).replace('-', ' ')}</span>
+                  <span class="badge badge-teal-subtle">{(item.data.category as string).replace('-', ' ')}</span>
                 )}
               </div>
             </div>
             <p class="item-desc">{item.data.description}</p>
             <div class="item-bottom">
-              <span class="item-tags">
-                {item.data.tags.slice(0, 3).join(' \u00B7 ')}
-              </span>
+              <div class="item-tags">
+                {item.data.tags.slice(0, 3).map((tag: string) => (
+                  <span class="badge badge-amber-subtle">{tag}</span>
+                ))}
+              </div>
               <span class="item-date">{formatDate(item.date)} &rarr;</span>
             </div>
           </a>
@@ -80,26 +90,38 @@ function formatDate(date: Date): string {
 
 <script>
   document.addEventListener('DOMContentLoaded', () => {
-    const buttons = document.querySelectorAll('.filter-btn');
+    const typeButtons = document.querySelectorAll('.filter-btn:not(.tag-btn)');
+    const tagButtons = document.querySelectorAll('.tag-btn');
     const items = document.querySelectorAll('.item[data-type]');
 
-    buttons.forEach(btn => {
+    let activeType = 'all';
+    let activeTag = 'all';
+
+    function filterItems() {
+      items.forEach(item => {
+        const type = item.getAttribute('data-type');
+        const tags = item.getAttribute('data-tags') || '';
+        const typeMatch = activeType === 'all' || type === activeType;
+        const tagMatch = activeTag === 'all' || tags.split(',').includes(activeTag);
+        (item as HTMLElement).style.display = (typeMatch && tagMatch) ? '' : 'none';
+      });
+    }
+
+    typeButtons.forEach(btn => {
       btn.addEventListener('click', () => {
-        const filter = btn.getAttribute('data-filter');
-
-        // Update active button
-        buttons.forEach(b => b.classList.remove('active'));
+        activeType = btn.getAttribute('data-filter') || 'all';
+        typeButtons.forEach(b => b.classList.remove('active'));
         btn.classList.add('active');
+        filterItems();
+      });
+    });
 
-        // Filter items
-        items.forEach(item => {
-          const type = item.getAttribute('data-type');
-          if (filter === 'all' || type === filter) {
-            (item as HTMLElement).style.display = '';
-          } else {
-            (item as HTMLElement).style.display = 'none';
-          }
-        });
+    tagButtons.forEach(btn => {
+      btn.addEventListener('click', () => {
+        activeTag = btn.getAttribute('data-tag') || 'all';
+        tagButtons.forEach(b => b.classList.remove('active'));
+        btn.classList.add('active');
+        filterItems();
       });
     });
   });
@@ -211,11 +233,13 @@ function formatDate(date: Date): string {
     justify-content: space-between;
     align-items: center;
     gap: var(--space-4);
+    flex-wrap: wrap;
   }
 
   .item-tags {
-    font-size: var(--text-xs);
-    color: var(--text-tertiary);
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--space-1);
   }
 
   .item-date {
@@ -241,7 +265,7 @@ function formatDate(date: Date): string {
     .item-bottom {
       flex-direction: column;
       align-items: flex-start;
-      gap: var(--space-1);
+      gap: var(--space-2);
     }
   }
 </style>

--- a/src/pages/work/[...slug].astro
+++ b/src/pages/work/[...slug].astro
@@ -21,18 +21,17 @@ type Props = {
 const project = Astro.props;
 const { Content } = await project.render();
 
-// Format date helper
+// Format date as YYYY-MM-DD
 function formatDate(date: Date): string {
-  return date.toLocaleDateString('en-US', {
-    year: 'numeric',
-    month: 'long',
-    day: 'numeric'
-  });
+  const y = date.getFullYear();
+  const m = String(date.getMonth() + 1).padStart(2, '0');
+  const d = String(date.getDate()).padStart(2, '0');
+  return `${y}-${m}-${d}`;
 }
 
-// Format status helper
-function formatStatus(status: string): string {
-  return status.replace('-', ' ').replace(/\b\w/g, l => l.toUpperCase());
+// Format category for display
+function formatCategory(category: string): string {
+  return category.replace('-', ' ');
 }
 ---
 
@@ -46,95 +45,42 @@ function formatStatus(status: string): string {
       <div class="project-content">
         <!-- Project Header -->
         <header class="project-header">
-          <div class="breadcrumb">
-            <a href="/work">← Back to Work</a>
-          </div>
-
-          <div class="project-meta-header">
-            <div class="project-badges">
-              <span class="category-badge">{formatStatus(project.data.category)}</span>
-              {project.data.featured && <span class="featured-badge">Featured</span>}
-            </div>
-          </div>
-
           <h1 class="project-title">{project.data.title}</h1>
 
-          <div class="project-meta">
-            <div class="meta-grid">
-              <div class="meta-item">
-                <span class="meta-label">Timeline</span>
-                <span class="meta-value">
-                  {formatDate(project.data.startDate)}
-                  {project.data.endDate && ` - ${formatDate(project.data.endDate)}`}
-                </span>
-              </div>
-
-              <div class="meta-item">
-                <span class="meta-label">Category</span>
-                <span class="meta-value">{formatStatus(project.data.category)}</span>
-              </div>
-            </div>
+          <div class="post-meta">
+            <time datetime={project.data.startDate.toISOString()}>
+              {formatDate(project.data.startDate)}
+            </time>
+            <span class="meta-sep">|</span>
+            <span class="badge badge-gray-subtle">{project.data.type || 'work'}</span>
+            <span class="meta-sep">|</span>
+            <span class="badge badge-teal-subtle">{formatCategory(project.data.category)}</span>
+            {project.data.view_source && (
+              <>
+                <span class="meta-sep">|</span>
+                <a href={project.data.view_source} target="_blank" rel="noopener noreferrer" class="source-link">view source ↗</a>
+              </>
+            )}
           </div>
 
-          {project.data.technologies.length > 0 && (
-            <div class="project-technologies">
-              <h3>Technologies Used</h3>
-              <div class="tech-grid">
-                {project.data.technologies.map((tech) => (
-                  <span class="tech-tag">{tech}</span>
-                ))}
-              </div>
-            </div>
-          )}
-
-          {(project.data.url || project.data.github) && (
-            <div class="project-links">
-              {project.data.url && (
-                <a
-                  href={project.data.url}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  class="btn btn-primary"
-                >
-                  View Live Project ↗
-                </a>
-              )}
-              {project.data.github && (
-                <a
-                  href={project.data.github}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  class="btn btn-secondary"
-                >
-                  View Source ↗
-                </a>
-              )}
+          {project.data.tags.length > 0 && (
+            <div class="post-tags">
+              {project.data.tags.map((tag: string) => (
+                <span class="badge badge-amber-subtle">{tag}</span>
+              ))}
             </div>
           )}
         </header>
+
+        <!-- Dashed divider -->
+        <div class="dashed-divider" aria-hidden="true">
+          ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+        </div>
 
         <!-- Project Body -->
         <div class="project-body">
           <Content />
         </div>
-
-        <!-- Project Footer -->
-        <footer class="project-footer">
-          <div class="project-actions">
-            <a href="/work" class="btn btn-secondary">← Back to Work</a>
-          </div>
-
-          {project.data.tags.length > 0 && (
-            <div class="project-tags">
-              <h3>Tags</h3>
-              <div class="tags-list">
-                {project.data.tags.map((tag) => (
-                  <span class="tag">{tag}</span>
-                ))}
-              </div>
-            </div>
-          )}
-        </footer>
       </div>
     </div>
   </article>
@@ -146,175 +92,77 @@ function formatStatus(status: string): string {
   }
 
   .project-content {
-    max-width: 800px;
+    max-width: 48rem;
     margin: 0 auto;
   }
 
-  .breadcrumb {
-    margin-bottom: var(--space-8);
-  }
-
-  .breadcrumb a {
-    color: var(--text-secondary);
-    text-decoration: none;
-    font-size: var(--text-sm);
-    transition: color var(--transition-fast);
-  }
-
-  .breadcrumb a:hover {
-    color: var(--text-primary);
-    text-decoration: none;
-  }
-
   .project-header {
-    margin-bottom: var(--space-16);
-    border-bottom: 1px solid var(--border-primary);
-    padding-bottom: var(--space-8);
-  }
-
-  .project-meta-header {
-    margin-bottom: var(--space-6);
-  }
-
-  .project-badges {
-    display: flex;
-    flex-wrap: wrap;
-    gap: var(--space-2);
-  }
-
-  .category-badge,
-  .featured-badge {
-    font-size: var(--text-xs);
-    font-weight: 600;
-    padding: var(--space-1) var(--space-3);
-    border-radius: var(--radius);
-    text-transform: uppercase;
-    letter-spacing: 0.05em;
-  }
-
-  .category-badge {
-    background-color: var(--bg-tertiary);
-    color: var(--text-secondary);
-  }
-
-  .featured-badge {
-    background-color: var(--accent-secondary);
-    color: var(--text-inverse);
+    text-align: center;
+    margin-bottom: var(--space-8);
   }
 
   .project-title {
-    font-size: var(--text-4xl);
-    font-weight: 700;
-    color: var(--text-primary);
-    margin-bottom: var(--space-8);
-    line-height: var(--leading-tight);
-  }
-
-  .project-meta {
-    margin-bottom: var(--space-8);
-  }
-
-  .meta-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-    gap: var(--space-6);
-    background-color: var(--bg-secondary);
-    padding: var(--space-6);
-    border-radius: var(--radius-lg);
-    border: 1px solid var(--border-primary);
-  }
-
-  .meta-item {
-    display: flex;
-    flex-direction: column;
-    gap: var(--space-1);
-  }
-
-  .meta-label {
-    font-size: var(--text-xs);
-    font-weight: 600;
-    color: var(--text-tertiary);
-    text-transform: uppercase;
-    letter-spacing: 0.05em;
-  }
-
-  .meta-value {
-    font-size: var(--text-sm);
+    font-family: var(--font-pixel-square);
     font-weight: 500;
+    font-size: var(--text-4xl);
     color: var(--text-primary);
-  }
-
-  .project-technologies {
-    margin-bottom: var(--space-8);
-  }
-
-  .project-technologies h3 {
-    color: var(--text-primary);
-    font-size: var(--text-base);
-    font-weight: 600;
     margin-bottom: var(--space-3);
+    line-height: 1.2;
+    letter-spacing: 0.02em;
+    text-transform: lowercase;
   }
 
-  .tech-grid {
+  .post-meta {
     display: flex;
+    align-items: center;
+    justify-content: center;
     flex-wrap: wrap;
     gap: var(--space-2);
-  }
-
-  .tech-tag {
-    background-color: var(--bg-tertiary);
-    color: var(--text-secondary);
-    font-size: var(--text-xs);
-    padding: var(--space-2) var(--space-3);
-    border-radius: var(--radius);
-    font-weight: 500;
-    border: 1px solid var(--border-secondary);
-  }
-
-  .project-links {
-    display: flex;
-    gap: var(--space-4);
-    flex-wrap: wrap;
-  }
-
-  .btn {
-    display: inline-flex;
-    align-items: center;
-    padding: var(--space-3) var(--space-6);
-    border-radius: var(--radius);
+    font-family: var(--font-geist-mono);
     font-size: var(--text-sm);
-    font-weight: 500;
+    color: var(--text-tertiary);
+    margin-bottom: var(--space-5);
+  }
+
+  .meta-sep {
+    color: var(--text-tertiary);
+    opacity: 0.5;
+  }
+
+  .source-link {
+    font-family: var(--font-geist-mono);
+    font-size: var(--text-sm);
+    color: var(--text-secondary);
     text-decoration: none;
-    transition: all var(--transition);
-    border: 1px solid;
+    transition: color var(--transition-fast);
   }
 
-  .btn-primary {
-    background-color: var(--text-primary);
-    color: var(--bg-primary);
-    border-color: var(--text-primary);
-  }
-
-  .btn-primary:hover {
-    background-color: var(--text-secondary);
-    border-color: var(--text-secondary);
-    text-decoration: none;
-  }
-
-  .btn-secondary {
-    background-color: transparent;
+  .source-link:hover {
     color: var(--text-primary);
-    border-color: var(--border-primary);
+    text-decoration: underline;
   }
 
-  .btn-secondary:hover {
-    background-color: var(--bg-hover);
-    border-color: var(--border-hover);
-    text-decoration: none;
+  .post-tags {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: var(--space-2);
+    margin-bottom: var(--space-6);
+  }
+
+  .dashed-divider {
+    font-family: var(--font-geist-mono);
+    color: var(--text-tertiary);
+    font-size: var(--text-xs);
+    overflow: hidden;
+    white-space: nowrap;
+    width: 100%;
+    margin-bottom: var(--space-10);
+    opacity: 0.5;
+    line-height: 1;
   }
 
   .project-body {
-    margin-bottom: var(--space-16);
     line-height: var(--leading-relaxed);
   }
 
@@ -410,42 +258,10 @@ function formatStatus(status: string): string {
     color: var(--text-primary);
   }
 
-  .project-footer {
-    border-top: 1px solid var(--border-primary);
-    padding-top: var(--space-8);
-    display: flex;
-    flex-direction: column;
-    gap: var(--space-8);
-  }
-
-  .project-actions {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    flex-wrap: wrap;
-    gap: var(--space-4);
-  }
-
-  .project-tags h3 {
-    color: var(--text-primary);
-    font-size: var(--text-lg);
-    font-weight: 600;
-    margin-bottom: var(--space-4);
-  }
-
-  .tags-list {
-    display: flex;
-    flex-wrap: wrap;
-    gap: var(--space-2);
-  }
-
-  .tag {
-    background-color: var(--bg-tertiary);
-    color: var(--text-secondary);
-    font-size: var(--text-xs);
-    padding: var(--space-1) var(--space-2);
-    border-radius: var(--radius-sm);
-    font-weight: 500;
+  .project-body :global(img) {
+    max-width: 100%;
+    height: auto;
+    border-radius: var(--radius);
   }
 
   /* Responsive Design */
@@ -456,19 +272,6 @@ function formatStatus(status: string): string {
 
     .project-title {
       font-size: var(--text-3xl);
-    }
-
-    .meta-grid {
-      grid-template-columns: 1fr;
-    }
-
-    .project-actions {
-      flex-direction: column;
-      align-items: stretch;
-    }
-
-    .project-links {
-      justify-content: center;
     }
   }
 </style>


### PR DESCRIPTION
## Summary
- **Resume redesign**: Real professional data (Fountain & Root Inc.), collapsible experience sections, dashed-box section headers, two-column education, color-coded skill badges
- **Nav & listing page**: Renamed "work" tab to "blog", removed H1, changed filter label to "all types"
- **Detail pages**: Standardized blog/project pages with consistent meta line (date | type | category | view source), unified badge colors
- **Content schemas**: Added `view_source` and `type` fields to blog and project collections
- **Claude skills**: Added `/new-blog-post`, `/new-project`, and `/edit-copy` slash commands for content workflows

## Test plan
- [x] Verify resume page renders with collapsible dropdowns, dashed-box headers, and two-column education
- [x] Verify "blog" nav tab highlights correctly for both `/work` and `/blog` paths
- [x] Verify type and tag filters work on the blog listing page
- [x] Verify blog and project detail pages show consistent meta lines
- [x] Test `/new-blog-post`, `/new-project`, `/edit-copy` skills in Claude Code
- [x] Check mobile responsiveness on all updated pages
- [x] Run `npm run build` with no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)