### PR TITLE
Remove "Fisher College of Business" from college section on resume page

### DIFF
--- a/src/pages/resume.astro
+++ b/src/pages/resume.astro
@@ -369,7 +369,7 @@ import SocialLinks from "../components/SocialLinks.astro";
                     <p class="education-degree">Masters of Science in Analytics</p>
                 </div>
                 <div class="education-col">
-                    <h3 class="education-school">The Ohio State University, Fisher College of Business</h3>
+                    <h3 class="education-school">The Ohio State University</h3>
                     <p class="education-degree">Bachelor of Science in Business Administration</p>
                 </div>
             </div>


### PR DESCRIPTION
## Summary
- Removed \`, Fisher College of Business\` from the Ohio State University entry in the Education section of the resume page

## Linear issue
https://linear.app/andrewgetz/issue/SELF-17/remove-fisher-college-of-business-from-college-section-on-resume-page

## Test plan
- [x] \`npm run build\` passes
- [x] Education section on \`/resume\` shows only \`The Ohio State University\`
- [x] \`Bachelor of Science in Business Administration\` degree line is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)