### PR TITLE
fix: override smol-toml to 1.6.1 to resolve DoS vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4584,9 +4584,9 @@
       "license": "MIT"
     },
     "node_modules/smol-toml": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.6.0.tgz",
-      "integrity": "sha512-4zemZi0HvTnYwLfrpk/CF9LOd9Lt87kAt50GnqhMpyF9U3poDAP2+iukq2bZsO/ufegbYehBkqINbsWxj4l4cw==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.6.1.tgz",
+      "integrity": "sha512-dWUG8F5sIIARXih1DTaQAX4SsiTXhInKf1buxdY9DIg4ZYPZK5nGM1VRIYmEbDbsHt7USo99xSLFu5Q1IqTmsg==",
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">= 18"

--- a/package.json
+++ b/package.json
@@ -8,6 +8,9 @@
     "preview": "astro preview",
     "astro": "astro"
   },
+  "overrides": {
+    "smol-toml": "^1.6.1"
+  },
   "dependencies": {
     "astro": "^5.17.1",
     "geist": "^1.7.0"


### PR DESCRIPTION
## Summary
- Adds npm override for `smol-toml` to `^1.6.1`, fixing Dependabot alert #16 (medium severity DoS via TOML documents with thousands of consecutive commented lines)

## Test plan
- [x] `npm run build` passes
- [x] `npm ls smol-toml` confirms 1.6.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)